### PR TITLE
Add support for coverageTypes API parameter

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -193,6 +193,23 @@ func (ac *APIClient) CreateOperator(email, password string) error {
 	return nil
 }
 
+// CreateOperatorWithRequest sends a request to create an operator with the email, password, coverageTypes (and any other options) defined by req.
+func (ac *APIClient) CreateOperatorWithRequest(req createOperatorRequest) error {
+	params := &apiParams{
+		method:      "POST",
+		path:        "/v1/operators",
+		contentType: "application/json",
+		body:        (&req).JSON(),
+	}
+	resp, err := ac.callAPI(params)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
 // VerifyOperator sends a token to complete an operator creation process.
 func (ac *APIClient) VerifyOperator(token string) error {
 	params := &apiParams{

--- a/api_client.go
+++ b/api_client.go
@@ -176,7 +176,7 @@ func (ac *APIClient) GetSupportToken() (string, error) {
 	return respBody.Token, nil
 }
 
-// CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The CreateOperatorWithRequest() function is newer and supports the newer API's params.)
+// CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The newer CreateOperatorWithRequest() supports all of the API parameters.)
 func (ac *APIClient) CreateOperator(email, password string) error {
 	req := CreateOperatorRequest{Email: email, Password: password}
 	return ac.CreateOperatorWithRequest(req)

--- a/api_client.go
+++ b/api_client.go
@@ -193,6 +193,23 @@ func (ac *APIClient) CreateOperator(email, password string) error {
 	return nil
 }
 
+// CreateOperatorWithCoverageTypes sends a request to create an operator with the specified email, password, and coverageTypes.
+func (ac *APIClient) CreateOperatorWithCoverageTypes(email, password string, coverageTypes []string) error {
+	params := &apiParams{
+		method:      "POST",
+		path:        "/v1/operators",
+		contentType: "application/json",
+		body:        (&createOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}).JSON(),
+	}
+	resp, err := ac.callAPI(params)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
 // CreateOperatorWithRequest sends a request to create an operator with the email, password, coverageTypes (and any other options) defined by req.
 func (ac *APIClient) CreateOperatorWithRequest(req createOperatorRequest) error {
 	params := &apiParams{

--- a/api_client.go
+++ b/api_client.go
@@ -176,13 +176,13 @@ func (ac *APIClient) GetSupportToken() (string, error) {
 	return respBody.Token, nil
 }
 
-// CreateOperator sends a request to create an operator with the specified email & password.
+// CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The CreateOperatorWithRequest function is newer and supports the newer API's params.)
 func (ac *APIClient) CreateOperator(email, password string) error {
 	params := &apiParams{
 		method:      "POST",
 		path:        "/v1/operators",
 		contentType: "application/json",
-		body:        (&createOperatorRequest{Email: email, Password: password}).JSON(),
+		body:        (&CreateOperatorRequest{Email: email, Password: password}).JSON(),
 	}
 	resp, err := ac.callAPI(params)
 	if err != nil {
@@ -199,7 +199,7 @@ func (ac *APIClient) CreateOperatorWithCoverageTypes(email, password string, cov
 		method:      "POST",
 		path:        "/v1/operators",
 		contentType: "application/json",
-		body:        (&createOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}).JSON(),
+		body:        (&CreateOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}).JSON(),
 	}
 	resp, err := ac.callAPI(params)
 	if err != nil {
@@ -210,8 +210,8 @@ func (ac *APIClient) CreateOperatorWithCoverageTypes(email, password string, cov
 	return nil
 }
 
-// CreateOperatorWithRequest sends a request to create an operator with the email, password, coverageTypes (and any other options) defined by req.
-func (ac *APIClient) CreateOperatorWithRequest(req createOperatorRequest) error {
+// CreateOperatorWithRequest sends a request to create an operator, whose email, password, and coverageTypes properties are defined by req.
+func (ac *APIClient) CreateOperatorWithRequest(req CreateOperatorRequest) error {
 	params := &apiParams{
 		method:      "POST",
 		path:        "/v1/operators",

--- a/api_client.go
+++ b/api_client.go
@@ -178,36 +178,14 @@ func (ac *APIClient) GetSupportToken() (string, error) {
 
 // CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The CreateOperatorWithRequest function is newer and supports the newer API's params.)
 func (ac *APIClient) CreateOperator(email, password string) error {
-	params := &apiParams{
-		method:      "POST",
-		path:        "/v1/operators",
-		contentType: "application/json",
-		body:        (&CreateOperatorRequest{Email: email, Password: password}).JSON(),
-	}
-	resp, err := ac.callAPI(params)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return nil
+	req := CreateOperatorRequest{Email: email, Password: password}
+	return ac.CreateOperatorWithRequest(req)
 }
 
 // CreateOperatorWithCoverageTypes sends a request to create an operator with the specified email, password, and coverageTypes.
 func (ac *APIClient) CreateOperatorWithCoverageTypes(email, password string, coverageTypes []string) error {
-	params := &apiParams{
-		method:      "POST",
-		path:        "/v1/operators",
-		contentType: "application/json",
-		body:        (&CreateOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}).JSON(),
-	}
-	resp, err := ac.callAPI(params)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return nil
+	req := CreateOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}
+	return ac.CreateOperatorWithRequest(req)
 }
 
 // CreateOperatorWithRequest sends a request to create an operator, whose email, password, and coverageTypes properties are defined by req.

--- a/api_client.go
+++ b/api_client.go
@@ -176,15 +176,9 @@ func (ac *APIClient) GetSupportToken() (string, error) {
 	return respBody.Token, nil
 }
 
-// CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The CreateOperatorWithRequest function is newer and supports the newer API's params.)
+// CreateOperator sends a request to create an operator with the specified email & password. (This function exists because it predates the addition of the coverageTypes API parameter. The CreateOperatorWithRequest() function is newer and supports the newer API's params.)
 func (ac *APIClient) CreateOperator(email, password string) error {
 	req := CreateOperatorRequest{Email: email, Password: password}
-	return ac.CreateOperatorWithRequest(req)
-}
-
-// CreateOperatorWithCoverageTypes sends a request to create an operator with the specified email, password, and coverageTypes.
-func (ac *APIClient) CreateOperatorWithCoverageTypes(email, password string, coverageTypes []string) error {
-	req := CreateOperatorRequest{Email: email, Password: password, CoverageTypes: coverageTypes}
 	return ac.CreateOperatorWithRequest(req)
 }
 

--- a/sdk.go
+++ b/sdk.go
@@ -140,13 +140,15 @@ func parseGetSupportTokenResponse(resp *http.Response) *GetSupportTokenResponse 
 	return &r
 }
 
-type createOperatorRequest struct {
+// CreateOperatorRequest defines the email, password, and coverage type(s) of the operator to be created
+type CreateOperatorRequest struct {
 	Email         string   `json:"email"`
 	Password      string   `json:"password"`
 	CoverageTypes []string `json:"coverageTypes"`
 }
 
-func (r *createOperatorRequest) JSON() string {
+// JSON encodes a CreateOperatorRequest object
+func (r *CreateOperatorRequest) JSON() string {
 	return toJSON(r)
 }
 

--- a/sdk.go
+++ b/sdk.go
@@ -141,8 +141,9 @@ func parseGetSupportTokenResponse(resp *http.Response) *GetSupportTokenResponse 
 }
 
 type createOperatorRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	Email         string   `json:"email"`
+	Password      string   `json:"password"`
+	CoverageTypes []string `json:"coverageTypes"`
 }
 
 func (r *createOperatorRequest) JSON() string {

--- a/sdk.go
+++ b/sdk.go
@@ -144,7 +144,7 @@ func parseGetSupportTokenResponse(resp *http.Response) *GetSupportTokenResponse 
 type CreateOperatorRequest struct {
 	Email         string   `json:"email"`
 	Password      string   `json:"password"`
-	CoverageTypes []string `json:"coverageTypes"`
+	CoverageTypes []string `json:"coverageTypes,omitempty"`
 }
 
 // JSON encodes a CreateOperatorRequest object


### PR DESCRIPTION
A future version of the Soracom API is expected to support an additional `coverageTypes` parameter to the `createOperator` API call. This PR adds support for the new parameter, while remaining compatible with existing client code.