### PR TITLE
Modify ListEventHandlers Parameter

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -876,7 +876,11 @@ type ListEventHandlersOptions struct {
 }
 
 func (leho *ListEventHandlersOptions) String() string {
-	return leho.Target
+	var s = make([]string, 0, 10)
+	if leho.Target != "" {
+		s = append(s, "target="+leho.Target)
+	}
+	return strings.Join(s, "&")
 }
 
 func parseListEventHandlersResponse(resp *http.Response) ([]EventHandler, error) {


### PR DESCRIPTION
ListEventHandlersを呼び出す際に、パラメータの「target=」が付与されてなかったので、絞り込みがされていませんでした。
修正を行いましたので、ご確認をお願いいたします。