### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -1174,7 +1174,7 @@ func (ac *APIClient) CreateCoupon(options *CreatedCouponOptions) (*CreatedCoupon
 	return cc, nil
 }
 
-// CreateCredential sends a request to create a brand-new credential
+// CreateCredentialWithName sends a request to create a brand-new credential
 func (ac *APIClient) CreateCredentialWithName(name string, options *CredentialOptions) (*CreatedCredential, error) {
 	params := &apiParams{
 		method:      "POST",


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?