### PR TITLE
Add HTTP status code field into APIError struct

### DIFF
--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1250,6 +1250,15 @@ func TestGetGroup(t *testing.T) {
 	}
 }
 
+func TestGetGroupError(t *testing.T) {
+	_, err := apiClient.GetGroup("wrong_group_id")
+	apiError := err.(*APIError)
+
+	if apiError.ErrorCode != "404" {
+		t.Fatalf("GetGroup() returns wrong http status code")
+	}
+}
+
 func TestListSubscribersInGroup(t *testing.T) {
 	name := fmt.Sprintf("group-name-for-test-%d", time.Now().Unix())
 	groupCreated, err := apiClient.CreateGroup(Tags{"name": name, "test-tag": "test-value"})

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1250,15 +1250,6 @@ func TestGetGroup(t *testing.T) {
 	}
 }
 
-func TestGetGroupError(t *testing.T) {
-	_, err := apiClient.GetGroup("wrong_group_id")
-	apiError := err.(*APIError)
-
-	if apiError.ErrorCode != "404" {
-		t.Fatalf("GetGroup() returns wrong http status code")
-	}
-}
-
 func TestListSubscribersInGroup(t *testing.T) {
 	name := fmt.Sprintf("group-name-for-test-%d", time.Now().Unix())
 	groupCreated, err := apiClient.CreateGroup(Tags{"name": name, "test-tag": "test-value"})

--- a/api_error.go
+++ b/api_error.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -34,19 +35,16 @@ func NewAPIError(resp *http.Response) *APIError {
 	if strings.Index(ct, "text/plain") == 0 {
 		errorCode = "UNK0001"
 		message = readAll(resp.Body)
-	} else if strings.Index(ct, "application/json") == 0 {
+	} else {
 		if resp.StatusCode >= http.StatusBadRequest &&
 			resp.StatusCode < http.StatusInternalServerError {
 			aer := parseAPIErrorResponse(resp)
-			errorCode = aer.ErrorCode
+			errorCode = strconv.Itoa(resp.StatusCode)
 			message = fmt.Sprintf(aer.Message, aer.MessageArgs)
 		} else {
 			errorCode = ""
 			message = readAll(resp.Body)
 		}
-	} else {
-		errorCode = "INT0001"
-		message = "Content-Type: " + ct + " is not supported"
 	}
 	return &APIError{
 		ErrorCode: errorCode,

--- a/api_error.go
+++ b/api_error.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 )
 
 // APIError represents an error ocurred while calling API
 type APIError struct {
-	ErrorCode string
-	Message   string
+	HTTPStatusCode int
+	ErrorCode      string
+	Message        string
 }
 
 type apiErrorResponse struct {
@@ -35,20 +35,24 @@ func NewAPIError(resp *http.Response) *APIError {
 	if strings.Index(ct, "text/plain") == 0 {
 		errorCode = "UNK0001"
 		message = readAll(resp.Body)
-	} else {
+	} else if strings.Index(ct, "application/json") == 0 {
 		if resp.StatusCode >= http.StatusBadRequest &&
 			resp.StatusCode < http.StatusInternalServerError {
 			aer := parseAPIErrorResponse(resp)
-			errorCode = strconv.Itoa(resp.StatusCode)
+			errorCode = aer.ErrorCode
 			message = fmt.Sprintf(aer.Message, aer.MessageArgs)
 		} else {
 			errorCode = ""
 			message = readAll(resp.Body)
 		}
+	} else {
+		errorCode = "INT0001"
+		message = "Content-Type: " + ct + " is not supported"
 	}
 	return &APIError{
-		ErrorCode: errorCode,
-		Message:   message,
+		HTTPStatusCode: resp.StatusCode,
+		ErrorCode:      errorCode,
+		Message:        message,
 	}
 }
 

--- a/api_error_test.go
+++ b/api_error_test.go
@@ -1,0 +1,89 @@
+package soracom
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestTextPlainApiError(t *testing.T) {
+	r := ioutil.NopCloser(strings.NewReader("test"))
+	h := http.Header{}
+	h.Set("Content-Type", "text/plain")
+	res := &http.Response{
+		StatusCode: 404,
+		Body:       r,
+		Header:     h,
+	}
+
+	apiError := NewAPIError(res)
+	if apiError.HTTPStatusCode != 404 {
+		t.Fatalf("wrong http status code: %v", apiError.HTTPStatusCode)
+	}
+
+	if apiError.ErrorCode != "UNK0001" {
+		t.Fatalf("wrong error code: %v", apiError.ErrorCode)
+	}
+}
+
+func TestJsonClientApiError(t *testing.T) {
+	json := `{"code":"SEM0095"}`
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	res := &http.Response{
+		StatusCode: 404,
+		Body:       r,
+		Header:     h,
+	}
+
+	apiError := NewAPIError(res)
+	if apiError.HTTPStatusCode != 404 {
+		t.Fatalf("wrong http status code: %v", apiError.HTTPStatusCode)
+	}
+
+	if apiError.ErrorCode != "SEM0095" {
+		t.Fatalf("wrong error code: %v", apiError.ErrorCode)
+	}
+}
+
+func TestJsonServerApiError(t *testing.T) {
+	json := `{}`
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	res := &http.Response{
+		StatusCode: 500,
+		Body:       r,
+		Header:     h,
+	}
+
+	apiError := NewAPIError(res)
+	if apiError.HTTPStatusCode != 500 {
+		t.Fatalf("wrong http status code: %v", apiError.HTTPStatusCode)
+	}
+
+	if apiError.ErrorCode != "" {
+		t.Fatalf("wrong error code: %v", apiError.ErrorCode)
+	}
+}
+
+func TestNotSupportedContentTypeApiError(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/pdf")
+	res := &http.Response{
+		StatusCode: 415,
+		Header:     h,
+	}
+
+	apiError := NewAPIError(res)
+	if apiError.HTTPStatusCode != 415 {
+		t.Fatalf("wrong http status code: %v", apiError.HTTPStatusCode)
+	}
+
+	if apiError.ErrorCode != "INT0001" {
+		t.Fatalf("wrong error code: %v", apiError.ErrorCode)
+	}
+}


### PR DESCRIPTION
Hello.

Currently, if an error occurs in http get, http status code cannot be retrieved.
I submit this PR in order to get http status code.

Thanks.