### PR TITLE
Fix golint warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,8 @@ jobs:
 
     - name: Lint
       run: |
-        GOBIN=$PWD/bin go install golang.org/x/lint/golint
-        ./bin/golint ./...
+        GOBIN="$PWD/bin" go install golang.org/x/lint/golint
+        PATH="$PATH:$PWD/bin" make lint
 
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ setup:
 	go get .
 
 lint:
-	golint ./...
+	golint ./... \
+		| grep -v 'struct field ResourceUrl should be ResourceURL' \
+		| grep -v 'struct field AccessKeyId should be AccessKeyID' \
+		| grep -v 'struct field OperatorId should be OperatorID' \
+		| grep . ; \
+	EXIT_CODE=$$?; \
+	if [ $$EXIT_CODE -eq 0 ]; then exit 1; fi
 
 test:
 	go vet ./...

--- a/sdk.go
+++ b/sdk.go
@@ -1026,12 +1026,14 @@ func parseCreatedSubscriber(resp *http.Response) (*CreatedSubscriber, error) {
 	return &v, nil
 }
 
+// CreatedCouponOptions is a structure that represents the request option for CreateCoupon API.
 type CreatedCouponOptions struct {
 	Amount                 int    `json:"amount"`
 	ApplicableBillItemName string `json:"applicableBillItemName"`
 	ExpiryYearMonth        string `json:"expiryYearMonth"`
 }
 
+// CreatedCoupon is a structure that represents the created coupon from CreateCoupon API.
 type CreatedCoupon struct {
 	CouponCode             string `json:"couponCode"`
 	Amount                 int    `json:"amount"`
@@ -1054,11 +1056,13 @@ func (o *CreatedCouponOptions) JSON() string {
 	return toJSON(o)
 }
 
+// Credentials is a structure that represents API credentials.
 type Credentials struct {
 	AccessKeyId     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
 }
 
+// CredentialOptions is a structure that represents the request option for CreateCredentialWithName API.
 type CredentialOptions struct {
 	Type        string      `json:"type"`
 	Description string      `json:"description"`
@@ -1070,6 +1074,7 @@ func (o *CredentialOptions) JSON() string {
 	return toJSON(o)
 }
 
+// CreatedCredential is a structure that represents the created credentials from CreateCredentialWithName API.
 type CreatedCredential struct {
 	CredentialID     string          `json:"credentialsId"`
 	Type             string          `json:"type"`


### PR DESCRIPTION
This commit contains the following changes:

- Make golint to exit with illegal status when golint outputs any warning
- Fill godoc for exported items
- Ignore some golint warnings of struct field convention
  - These fields' name have been exported, so if it renames those that will be a breaking change. So this commit makes that to ignore them.
  - Unfortunately, golint doesn't (and probably won't) have a feature to ignore the linting line by line, so it ignores by golint command execution.