### PR TITLE
Cannot create x.509 credentials with the SDK

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -1058,8 +1058,11 @@ func (o *CreatedCouponOptions) JSON() string {
 
 // Credentials is a structure that represents API credentials.
 type Credentials struct {
-	AccessKeyId     string `json:"accessKeyId"`
-	SecretAccessKey string `json:"secretAccessKey"`
+	AccessKeyId          string `json:"accessKeyId,omitempty"`
+	SecretAccessKey      string `json:"secretAccessKey,omitempty"`
+	Certificate          string `json:"cert,omitempty"`
+	PrivateKey           string `json:"key,omitempty"`
+	CertificateAuthority string `json:"ca,omitempty"`
 }
 
 // CredentialOptions is a structure that represents the request option for CreateCredentialWithName API.


### PR DESCRIPTION
Add members to allow creation of x.509 certificate with the SDK.
As all members are not always used, add the attribute "omitempty" for JSON serialization

Fix #18