### PR TITLE
Fix E2E tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,36 +1,30 @@
 name: Go
 on: [push, pull_request]
 jobs:
-
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.17
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.17
-      id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
     - name: Format check
       run: |
-        GOBIN=$PWD/bin go install golang.org/x/tools/cmd/goimports
-        PATH="$PATH:$PWD/bin" make fmt-check
+        go install golang.org/x/tools/cmd/goimports@latest
+        make fmt-check
 
-    - name: Lint
-      run: |
-        GOBIN="$PWD/bin" go install golang.org/x/lint/golint
-        PATH="$PATH:$PWD/bin" make lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: 'latest'
 
     - name: Test
-      run: make test
+      run: go mod vendor && make test
       env:
         SORACOM_EMAIL_FOR_TEST: ${{ secrets.SORACOM_EMAIL_FOR_TEST }}
         SORACOM_PASSWORD_FOR_TEST: ${{ secrets.SORACOM_PASSWORD_FOR_TEST }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,10 +6,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
       id: go
 
     - name: Check out code into the Go module directory

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1106,14 +1106,18 @@ func TestCreateGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(g1.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(g1.GroupID)
+	}()
 
 	name := fmt.Sprintf("group-name-for-test-%d", time.Now().Unix())
 	g2, err := apiClient.CreateGroup(Tags{"name": name, "test-tag": "test-value"})
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(g2.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(g2.GroupID)
+	}()
 }
 
 func TestCreateGroupWithName(t *testing.T) {
@@ -1122,7 +1126,9 @@ func TestCreateGroupWithName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 	if group.Tags["name"] != name {
 		t.Fatalf("Created a group with wrong name")
 	}
@@ -1147,7 +1153,9 @@ func TestGetGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(groupCreated.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(groupCreated.GroupID)
+	}()
 
 	groupFound, err := apiClient.GetGroup(groupCreated.GroupID)
 	if err != nil {
@@ -1165,7 +1173,9 @@ func TestListSubscribersInGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(groupCreated.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(groupCreated.GroupID)
+	}()
 
 	for _, cs := range createdSubscribers {
 		_, err := apiClient.SetSubscriberGroup(cs.IMSI, groupCreated.GroupID)
@@ -1204,7 +1214,9 @@ func TestUpdateGroupConfigurations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	beamTCPConfig := &BeamTCPConfig{
 		Name:                "TCP Config Name 1",
@@ -1250,7 +1262,9 @@ func TestUpdateAirConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	airConfig1 := &AirConfig{
 		UseCustomDNS: true,
@@ -1298,7 +1312,9 @@ func TestUpdateBeamTCPConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	entryPoint1 := "tcp://beam.soracom.io:8023"
 	beamTCPConfig1 := &BeamTCPConfig{
@@ -1328,7 +1344,9 @@ func TestDeleteGroupConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	entryPoint1 := "tcp://beam.soracom.io:8023"
 	beamTCPConfig1 := &BeamTCPConfig{
@@ -1366,7 +1384,9 @@ func TestUpdateGroupTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	g, err := apiClient.UpdateGroupTags(group.GroupID, []Tag{
 		{TagName: "name1", TagValue: "value1"},
@@ -1387,7 +1407,9 @@ func TestDeleteGroupTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateGroup() failed: %v", err.Error())
 	}
-	defer apiClient.DeleteGroup(group.GroupID)
+	defer func() {
+		_ = apiClient.DeleteGroup(group.GroupID)
+	}()
 
 	g1, err := apiClient.UpdateGroupTags(group.GroupID, []Tag{
 		{TagName: "name1", TagValue: "value1"},

--- a/api_error.go
+++ b/api_error.go
@@ -23,7 +23,7 @@ type apiErrorResponse struct {
 func parseAPIErrorResponse(resp *http.Response) *apiErrorResponse {
 	var aer apiErrorResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&aer)
+	_ = dec.Decode(&aer)
 	return &aer
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/soracom/soracom-sdk-go
 
-go 1.12
+go 1.17
 
 require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 )
+
+require github.com/mattn/go-isatty v0.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaa
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/sdk.go
+++ b/sdk.go
@@ -100,6 +100,28 @@ func parseAuthResponse(resp *http.Response) *AuthResponse {
 	return &ar
 }
 
+// InitOperatorForSandboxRequest represents the request body of InitOperatorForSandbox.
+type InitOperatorForSandboxRequest struct {
+	Email                 string   `json:"email"`
+	Password              string   `json:"password"`
+	AuthKeyID             string   `json:"authKeyId"`
+	AuthKey               string   `json:"authKey"`
+	RegisterPaymentMethod bool     `json:"registerPaymentMethod"`
+	CoverageTypes         []string `json:"coverageTypes,omitempty"`
+}
+
+// JSON returns JSON string of InitOperatorForSandboxRequest.
+func (r *InitOperatorForSandboxRequest) JSON() string {
+	return toJSON(r)
+}
+
+// InitOperatorForSandboxResponse represents the response body InitOperatorForSandbox.
+type InitOperatorForSandboxResponse struct {
+	OperatorID string `json:"operatorId"`
+	APIKey     string `json:"apiKey"`
+	Token      string `json:"token"`
+}
+
 type generateAPITokenRequest struct {
 	Timeout int `json:"timeout_seconds"`
 }

--- a/sdk.go
+++ b/sdk.go
@@ -96,7 +96,7 @@ type AuthResponse struct {
 func parseAuthResponse(resp *http.Response) *AuthResponse {
 	var ar AuthResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&ar)
+	_ = dec.Decode(&ar)
 	return &ar
 }
 
@@ -139,7 +139,7 @@ type GenerateAPITokenResponse struct {
 func parseGenerateAPITokenResponse(resp *http.Response) *GenerateAPITokenResponse {
 	var r GenerateAPITokenResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&r)
+	_ = dec.Decode(&r)
 	return &r
 }
 
@@ -160,7 +160,7 @@ type GetSupportTokenResponse struct {
 func parseGetSupportTokenResponse(resp *http.Response) *GetSupportTokenResponse {
 	var r GetSupportTokenResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&r)
+	_ = dec.Decode(&r)
 	return &r
 }
 
@@ -197,7 +197,7 @@ type Operator struct {
 func parseOperator(resp *http.Response) *Operator {
 	var o Operator
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&o)
+	_ = dec.Decode(&o)
 	return &o
 }
 
@@ -354,11 +354,11 @@ func parseLinkHeader(linkHeader string) *PaginationKeys {
 		links := strings.Split(linkHeader, ",")
 		for _, link := range links {
 			s := strings.Split(link, ";")
-			url, err := url.Parse(strings.Trim(s[0], "<>"))
+			u, err := url.Parse(strings.Trim(s[0], "<>"))
 			if err != nil {
 				continue
 			}
-			lek := url.Query()["last_evaluated_key"][0]
+			lek := u.Query()["last_evaluated_key"][0]
 			rel := strings.Split(s[1], "=")[1]
 			if rel == "prev" {
 				pk.Prev = lek
@@ -395,7 +395,7 @@ func parseListSubscribersResponse(resp *http.Response) ([]Subscriber, *Paginatio
 		return nil, nil, err
 	}
 
-	linkHeader := resp.Header.Get(http.CanonicalHeaderKey("Link"))
+	linkHeader := resp.Header.Get("Link")
 	pk := parseLinkHeader(linkHeader)
 
 	return subs, pk, nil
@@ -404,7 +404,7 @@ func parseListSubscribersResponse(resp *http.Response) ([]Subscriber, *Paginatio
 func parseSubscriber(resp *http.Response) *Subscriber {
 	var sub Subscriber
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&sub)
+	_ = dec.Decode(&sub)
 	return &sub
 }
 
@@ -532,7 +532,7 @@ type AirStats struct {
 func parseAirStats(resp *http.Response) []AirStats {
 	var v []AirStats
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&v)
+	_ = dec.Decode(&v)
 	return v
 }
 
@@ -584,7 +584,7 @@ type BeamStats struct {
 func parseBeamStats(resp *http.Response) []BeamStats {
 	var v []BeamStats
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&v)
+	_ = dec.Decode(&v)
 	return v
 }
 
@@ -610,7 +610,7 @@ type exportAirStatsResponse struct {
 func parseExportAirStatsResponse(resp *http.Response) *exportAirStatsResponse {
 	var r exportAirStatsResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&r)
+	_ = dec.Decode(&r)
 	return &r
 }
 
@@ -631,7 +631,7 @@ type exportBeamStatsResponse struct {
 func parseExportBeamStatsResponse(resp *http.Response) *exportBeamStatsResponse {
 	var r exportBeamStatsResponse
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&r)
+	_ = dec.Decode(&r)
 	return &r
 }
 
@@ -702,7 +702,7 @@ func parseListGroupsResponse(resp *http.Response) ([]Group, *PaginationKeys, err
 		return nil, nil, err
 	}
 
-	linkHeader := resp.Header.Get(http.CanonicalHeaderKey("Link"))
+	linkHeader := resp.Header.Get("Link")
 	pk := parseLinkHeader(linkHeader)
 
 	return groups, pk, nil
@@ -719,7 +719,7 @@ func (r *createGroupRequest) JSON() string {
 func parseGroup(resp *http.Response) *Group {
 	var g Group
 	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&g)
+	_ = dec.Decode(&g)
 	return &g
 }
 
@@ -1169,7 +1169,7 @@ func parseListSessionEvents(resp *http.Response) ([]SessionEvent, *PaginationKey
 		return nil, nil, err
 	}
 
-	linkHeader := resp.Header.Get(http.CanonicalHeaderKey("Link"))
+	linkHeader := resp.Header.Get("Link")
 	pk := parseLinkHeader(linkHeader)
 	return events, pk, err
 }
@@ -1194,7 +1194,7 @@ func tagsToJSON(tags []Tag) string {
 
 func readAll(r io.Reader) string {
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	return buf.String()
 }
 


### PR DESCRIPTION
Currently, using `POST: /v1/sandbox/init` is the right way to initialize an operator, instead of creating an operator and registering the payment method manually.
The reason why changing this sequence is `POST: /v1/payment_method/token/.*` APIs are no longer available (somehow it has returned `403 Unauthorized`).

Of course, I think those unavailable APIs should be dropped from this SDK, but it would be better to do that in another pull request.