### PR TITLE
add binary parser config to AirConfig.

### DIFF
--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1277,7 +1277,9 @@ func TestUpdateAirConfig(t *testing.T) {
 			ReadOnly:    true,
 			AllowOrigin: "http://some.example.com",
 		},
-		UserData: "foobar",
+		UserData:            "foobar",
+		BinaryParserEnabled: true,
+		BinaryParserFormat:  "flag:0:bool:7 temp:1:int:13:/10 humid:3:uint:8:/100 lat::float:32 long:float:32",
 	}
 
 	g1, err := apiClient.UpdateAirConfig(group.GroupID, airConfig1)
@@ -1304,6 +1306,12 @@ func TestUpdateAirConfig(t *testing.T) {
 	if air1["userdata"].(string) != "foobar" {
 		t.Fatalf("Unexpected value found")
 	}
+	if air1["binaryParserEnabled"].(bool) != true {
+		t.Fatalf("Unexpected value found")
+	}
+	if air1["binaryParserFormat"].(string) != "flag:0:bool:7 temp:1:int:13:/10 humid:3:uint:8:/100 lat::float:32 long:float:32" {
+		t.Fatalf("Unexpected value found")
+	}
 
 	airConfig2 := &AirConfig{
 		UseCustomDNS: false,
@@ -1315,7 +1323,9 @@ func TestUpdateAirConfig(t *testing.T) {
 			ReadOnly:    false,
 			AllowOrigin: "http://any.example.com",
 		},
-		UserData: "helloworld",
+		UserData:            "helloworld",
+		BinaryParserEnabled: false,
+		BinaryParserFormat:  "",
 	}
 
 	g2, err := apiClient.UpdateAirConfig(group.GroupID, airConfig2)
@@ -1340,6 +1350,12 @@ func TestUpdateAirConfig(t *testing.T) {
 		t.Fatalf("Unexpected value found")
 	}
 	if air2["userdata"].(string) != "helloworld" {
+		t.Fatalf("Unexpected value found")
+	}
+	if air2["binaryParserEnabled"].(bool) != false {
+		t.Fatalf("Unexpected value found")
+	}
+	if air2["binaryParserFormat"].(string) != "" {
 		t.Fatalf("Unexpected value found")
 	}
 }

--- a/sdk.go
+++ b/sdk.go
@@ -755,10 +755,12 @@ type MetaData struct {
 
 // AirConfig holds configuration parameters for SORACOM Air
 type AirConfig struct {
-	UseCustomDNS bool     `json:"useCustomDns"`
-	DNSServers   []string `json:"dnsServers"`
-	MetaData     MetaData `json:"metadata"`
-	UserData     string   `json:"userdata"`
+	UseCustomDNS        bool     `json:"useCustomDns"`
+	DNSServers          []string `json:"dnsServers"`
+	MetaData            MetaData `json:"metadata"`
+	UserData            string   `json:"userdata"`
+	BinaryParserEnabled bool     `json:"binaryParserEnabled"`
+	BinaryParserFormat  string   `json:"binaryParserFormat"`
 }
 
 // JSON converts AirConfig into JSON string
@@ -768,6 +770,8 @@ func (ac *AirConfig) JSON() string {
 		{Key: "dnsServers", Value: ac.DNSServers},
 		{Key: "metadata", Value: ac.MetaData},
 		{Key: "userdata", Value: ac.UserData},
+		{Key: "binaryParserEnabled", Value: ac.BinaryParserEnabled},
+		{Key: "binaryParserFormat", Value: ac.BinaryParserFormat},
 	})
 }
 


### PR DESCRIPTION
UpdateAirConfig() won't reflect binary parser since there are missing elements in json converter.
So, I added elements for binary parser.