### PR TITLE
Add sim:getSim API (minimum)

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -620,6 +620,24 @@ func (ac *APIClient) DeleteSubscriberTag(imsi string, tagName string) error {
 	return nil
 }
 
+// GetSim gets information about a SIM specified by simID.
+func (ac *APIClient) GetSim(simID string) (*Sim, error) {
+	params := &apiParams{
+		method: "GET",
+		path:   "/v1/sims/" + simID,
+	}
+
+	resp, err := ac.callAPI(params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	sim := parseSim(resp)
+
+	return sim, nil
+}
+
 // GetAirStats gets stats of Air for a subscriber for a specified period
 func (ac *APIClient) GetAirStats(imsi string, from, to time.Time, period StatsPeriod) ([]AirStats, error) {
 	params := &apiParams{

--- a/sdk.go
+++ b/sdk.go
@@ -415,6 +415,13 @@ func parseSubscriber(resp *http.Response) *Subscriber {
 	return &sub
 }
 
+func parseSim(resp *http.Response) *Sim {
+	var sim Sim
+	dec := json.NewDecoder(resp.Body)
+	_ = dec.Decode(&sim)
+	return &sim
+}
+
 type updateSpeedClassRequest struct {
 	SpeedClass string `json:"speedClass"`
 }

--- a/sdk.go
+++ b/sdk.go
@@ -342,6 +342,12 @@ type Subscriber struct {
 	TerminationEnabled bool            `json:"terminationEnabled"`
 }
 
+// Sim represents a SIM resource in the SORACOM platform.
+type Sim struct {
+	SimID         string         `json:"simId"`
+	SessionStatus *SessionStatus `json:"sessionStatus"`
+}
+
 // PaginationKeys holds keys for pagination
 type PaginationKeys struct {
 	Prev string

--- a/sdk.go
+++ b/sdk.go
@@ -335,6 +335,7 @@ type Subscriber struct {
 	Plan               int             `json:"plan"`
 	SerialNumber       string          `json:"serialNumber"`
 	SessionStatus      *SessionStatus  `json:"sessionStatus"`
+	SimID              string          `json:"simId"`
 	SpeedClass         string          `json:"speedClass"`
 	Status             string          `json:"status"`
 	Tags               Tags            `json:"tags"`


### PR DESCRIPTION
Sim:getSimでSessionStatusを取得したく、APIの一部を実装しました

https://users.soracom.io/ja-jp/tools/api/reference/#/Sim/getSim